### PR TITLE
Optional HTTPS and Certificate authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The steps involved are:-
               https_certificate: <string> # local path to server certificate
               auth_cacert: <string> # local path to Certificate Authority cert
                                     # for Client Authentication
+              redirect_to_https: <boolean> # Redirect to https://[servername]/uri
               root: <string>
               error_page: <string>
               access_log: <string>

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The steps involved are:-
 4. Write an upstream configuration file, for each virtual host, to
    `/etc/nginx/conf.d/`.
 5. Write a certificate authority file, for client authentication, for each
-   virtual host, to `/etc/ssl/certs/`.
-6. Write a HTTPS private key file, for each virtual host, to
+   applicable virtual host, to `/etc/ssl/certs/`.
+6. Write a HTTPS private key file, for each applicable virtual host, to
    `/etc/ssl/private/`.
 7. Write a virtual host configuration, for each virtual host, to
    `/etc/nginx/sites-available/`.
@@ -30,8 +30,6 @@ The steps involved are:-
 
 1. One virtual host configuration template is used as the basis for all of the
    virtual hosts.
-2. Each of the virtual hosts is configured for HTTPS and with client
-   certificates for (optional) authentication.
 
 
 ## Information required by the module
@@ -65,12 +63,6 @@ The steps involved are:-
               name: <string> # A name for the vhost
               servername: <string> # The server name
               index: <string> # default: "index.html index.htm"
-              https_private_key: <string> # local path to private key (used by
-                                          # droid to copy the key to the nginx
-                                          # host)
-              https_certificate: <string> # local path to server certificate
-              auth_cacert: <string> # local path to Certificate Authority cert
-                                    # for Client Authentication
 
 
 3. A list of one or more upstream configurations, as follows:-
@@ -97,6 +89,12 @@ The steps involved are:-
 
         nginx_vhosts:
             -
+              https_private_key: <string> # local path to private key (used by
+                                          # droid to copy the key to the nginx
+                                          # host)
+              https_certificate: <string> # local path to server certificate
+              auth_cacert: <string> # local path to Certificate Authority cert
+                                    # for Client Authentication
               root: <string>
               error_page: <string>
               access_log: <string>

--- a/assets/vhost.conf.template
+++ b/assets/vhost.conf.template
@@ -54,4 +54,8 @@ server {
     {{{ item.extra_options }}}
 {{/if}}
 
+{{#if item.redirect_to_https}}
+    return 301 https://$host$request_uri;
+{{/if}}
+
 }

--- a/assets/vhost.conf.template
+++ b/assets/vhost.conf.template
@@ -10,15 +10,19 @@ server {
     listen {{{ . }}};
 {{/each}}
 
+{{#if item.https_certificate}}
     # HTTPS
     ssl_certificate /etc/ssl/certs/{{{ item.name }}}.crt.pem;
     ssl_certificate_key /etc/ssl/private/{{{ item.name }}}.key;
     proxy_set_header Host $host;
+{{/if}}
 
+{{#if item.auth_cacert}}
     # Authentication by Client Certificate
     ssl_client_certificate /etc/ssl/certs/{{{ item.name }}}.cacert.pem;
     ssl_verify_client optional;
     proxy_set_header X_CLIENT_CERT $ssl_client_verify;
+{{/if}}
 
 {{#if item.root }}
     root {{{ item.root }}};

--- a/droid.yml
+++ b/droid.yml
@@ -94,6 +94,7 @@ tasks:
           src: "!{{ item.auth_cacert }}"
           dest: "/etc/ssl/certs/{{ item.name }}.cacert.pem"
       with_items: nginx_vhosts
+      with_items_filter: "item['auth_cacert']"
     -
       name: "Copy HTTPS private key"
       command: "fs:copy"
@@ -101,6 +102,7 @@ tasks:
           src: "!{{ item.https_private_key }}"
           dest: "/etc/ssl/private/{{ item.name }}.key"
       with_items: nginx_vhosts
+      with_items_filter: "item['https_private_key']"
     -
       name: "Copy HTTPS certificate"
       command: "fs:copy"
@@ -108,6 +110,7 @@ tasks:
           src: "!{{ item.https_certificate }}"
           dest: "/etc/ssl/certs/{{ item.name }}.crt.pem"
       with_items: nginx_vhosts
+      with_items_filter: "item['https_certificate']"
     -
       name: "Create vhosts"
       command: "fs:copy"


### PR DESCRIPTION
- An `nginx_vhosts` vhost is configured for HTTPS when it has a value for `https_certificate`
- Similarly for Cert auth, when it has a value for `auth_cacert`
- A vhost with a value for `redirect_to_https` is configured to redirect to HTTPS with the same host and uri
